### PR TITLE
Fixing the location accuracy condition

### DIFF
--- a/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
+++ b/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
@@ -70,7 +70,7 @@ public class CoronaApplication extends Application implements Configuration.Prov
                     if (l == null) {
                         continue;
                     }
-                    if (lastKnownLocation == null || l.getAccuracy() > lastKnownLocation.getAccuracy()) {
+                    if (lastKnownLocation == null || (l.hasAccuracy() && l.getAccuracy() < lastKnownLocation.getAccuracy())) {
                         lastKnownLocation = l;
                     }
                 }catch (SecurityException e){


### PR DESCRIPTION
Higher the number returned by getAccuracy method, lower is the accuracy.
Link to the docs:
https://developer.android.com/reference/android/location/Location#getAccuracy()

Also, we should be checking if accuracy is present for the location or not.